### PR TITLE
Make acorn allow import/export

### DIFF
--- a/bin/jscc-cli
+++ b/bin/jscc-cli
@@ -57,6 +57,9 @@ process.stdin.on('end', function() {
         ast = acorn.parse(input_js, {
             ecmaVersion: 6,
             ranges: true,
+            sourceType: "module",
+            allowImportExportEverywhere: true,
+            allowReturnOutsideFunction: true,
             plugins: { jsx: true }
         });
 


### PR DESCRIPTION
`allowImportExportEverywhere` is necessary for acorn (the js parser) to allow for `import` and `export` syntax, now common to ECMAScript2015.

Thank you!